### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.5
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+COPY *.py ./
+CMD ./format.py -q -f md -i - -o -

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This simple tool allows you to convert a full configuration backup of a *pf*Sens
     * defusedxml==0.5.0
     * PyYAML==3.12
 
+or
+
+* Docker
+
 ## Screenshots
 
 **Before:** Configuration backup as XML
@@ -58,6 +62,28 @@ parse.py [-h] input_path
 Examples:
 ```
 ./parse.py config-backup.xml
+```
+
+### Usage with Docker
+
+When using pfFocus via Docker, you don't need to download it from Github, and you don't need to install Python or any libraries. Only Docker is required.
+
+It runs this command inside Docker: `./format.py -q -f md -i - -o -`, which means it works with `STDIN` and `STDOUT` instead of files.
+
+```bash
+docker run --rm -i hugojosefson/pffocus < input.xml > output.md
+```
+
+If you want you can set up an alias for it in bash:
+
+```bash
+alias pffocus="docker run --rm -i hugojosefson/pffocus"
+```
+
+Then you can use it like a normal Unix command, with pipes and redirects:
+
+```bash
+pffocus < input.xml > output.md
 ```
 
 ## Roadmap

--- a/parse.py
+++ b/parse.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import io
+import sys
 from pprint import pprint
 from xml.sax import ContentHandler
 
@@ -71,8 +72,12 @@ class PfSenseContentHandler(ContentHandler):
 
 def parse_pfsense(input_path, document):
     handler = PfSenseContentHandler(document)
-    with open(input_path, 'rb') as input_file:
-        parse(input_file, handler)
+    if input_path == '-':
+        with sys.stdin as input_file:
+            parse(input_file, handler)
+    else:
+        with open(input_path, 'rb') as input_file:
+            parse(input_file, handler)
 
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Hi!

Thank you for this tool, it was exactly what I was looking for to visualize my configuration :)

I have added a `Dockerfile`, and instructions to `README.md` for using pfFocus via Docker. Using it with Docker requires no download from Github, no Python and no installation of libraries.

Only building pfFocus for Docker, requires all the download and installation steps, but that is handled by automation on Docker Hub. That is also where it is made available for use.

Please let me know if you have any questions!